### PR TITLE
Update DappNode package config

### DIFF
--- a/configuration/docker/Dockerfile
+++ b/configuration/docker/Dockerfile
@@ -7,8 +7,8 @@ RUN apk --no-cache add git nano
 # Set workdir
 WORKDIR /root
 
-# Try to get upstream version (default v0.37.0-beta)
-ARG UPSTREAM_VER=v0.37.0-beta
+# Try to get upstream version (default v0.44.0-beta)
+ARG UPSTREAM_VER=v0.44.0-beta
 
 # Clone and make TrueBlocks Core
 # make -j 5 is a fairly safe number

--- a/configuration/main.go
+++ b/configuration/main.go
@@ -18,7 +18,7 @@ type ConfigurationItem struct {
 	Rpc            string
 	ChainId        string
 	Symbol         string
-	IpfsGateway    string
+	// IpfsGateway    string
 	LocalExplorer  string
 	RemoteExplorer string
 	ScraperArgs    string
@@ -32,6 +32,7 @@ type GlobalConfiguration struct {
 	MonitorArgs  string
 	MonitorFile  string
 	EtherscanKey string
+	DefaultGateway string
 }
 
 type ConfigurationPost struct {
@@ -47,9 +48,9 @@ func EnvsFromConfiguration(item ConfigurationItem) string {
 	b.WriteString(prefix + "RPCPROVIDER=" + item.Rpc + "\n")
 	b.WriteString(prefix + "SYMBOL=" + item.Symbol + "\n")
 
-	if item.IpfsGateway != "" {
-		b.WriteString(prefix + "PINGATEWAY=" + item.IpfsGateway + "\n")
-	}
+	// if item.IpfsGateway != "" {
+	// 	b.WriteString(prefix + "PINGATEWAY=" + item.IpfsGateway + "\n")
+	// }
 	if item.LocalExplorer != "" {
 		b.WriteString(prefix + "LOCALEXPLORER=" + item.LocalExplorer + "\n")
 	}
@@ -96,7 +97,8 @@ func SaveConfiguration(path string, config ConfigurationPost) (err error) {
 		fmt.Sprint("export RUN_SCRAPER=", config.Global.RunScraper),
 		fmt.Sprint("export BOOTSTRAP_BLOOM_FILTERS=", config.Global.InitBlooms),
 		fmt.Sprint("export BOOTSTRAP_FULL_INDEX=", config.Global.InitIndex),
-		fmt.Sprint("export TB_SETTINGS_ETHERSCANKEY=", normalizeUserInput(config.Global.EtherscanKey)),
+		fmt.Sprint("export TB_KEYS_ETHERSCAN_APIKEY=", normalizeUserInput(config.Global.EtherscanKey)),
+		fmt.Sprint("export TB_SETTINGS_DEFAULTGATEWAY=", config.Global.DefaultGateway),
 	}
 	if config.Global.MonitorArgs != "" {
 		lines = append(lines, fmt.Sprint("export MONITORS_ARGS=", normalizeUserInput(config.Global.MonitorArgs)))

--- a/configuration/main.go
+++ b/configuration/main.go
@@ -18,7 +18,7 @@ type ConfigurationItem struct {
 	Rpc            string
 	ChainId        string
 	Symbol         string
-	// IpfsGateway    string
+	IpfsGateway    string
 	LocalExplorer  string
 	RemoteExplorer string
 	ScraperArgs    string
@@ -48,9 +48,9 @@ func EnvsFromConfiguration(item ConfigurationItem) string {
 	b.WriteString(prefix + "RPCPROVIDER=" + item.Rpc + "\n")
 	b.WriteString(prefix + "SYMBOL=" + item.Symbol + "\n")
 
-	// if item.IpfsGateway != "" {
-	// 	b.WriteString(prefix + "PINGATEWAY=" + item.IpfsGateway + "\n")
-	// }
+	if item.IpfsGateway != "" {
+		b.WriteString(prefix + "IPFSGATEWAY=" + item.IpfsGateway + "\n")
+	}
 	if item.LocalExplorer != "" {
 		b.WriteString(prefix + "LOCALEXPLORER=" + item.LocalExplorer + "\n")
 	}

--- a/configuration/static/index.html
+++ b/configuration/static/index.html
@@ -378,14 +378,14 @@
                         </span>
                     </div>
                 </label>
-                <label>
+                <!-- <label>
                     <span>
                         IPFS Gateway:
                     </span>
                     <div class="field">
                         <input type="url" name="ipfsGateway" placeholder="https://ipfs.unchainedindex.io/ipfs/">
                     </div>
-                </label>
+                </label> -->
                 <label>
                     <span>
                         Local Explorer:
@@ -494,6 +494,17 @@
                     </div>
                     <p class="explainer">
                         Etherscan API key is used to download ABI data
+                    </p>
+                </label>
+                <label>
+                    <span>
+                       IPFS Gateway
+                    </span>
+                    <div class="field">
+                        <input type="text" name="defaultGateway" placeholder="https://ipfs.unchainedindex.io/ipfs/">
+                    </div>
+                    <p class="explainer">
+                        Default IPFS Gateway
                     </p>
                 </label>
 
@@ -660,7 +671,7 @@
                     row.querySelector('[name=rpc]').value = item.Rpc || '';
                     row.querySelector('[name=chainId]').value = item.ChainId || '';
                     row.querySelector('[name=symbol]').value = item.Symbol || '';
-                    row.querySelector('[name=ipfsGateway]').value = item.IpfsGateway || '';
+                    // row.querySelector('[name=ipfsGateway]').value = item.IpfsGateway || '';
                     row.querySelector('[name=localExplorer]').value = item.LocalExplorer || '';
                     row.querySelector('[name=remoteExplorer]').value = item.RemoteExplorer || '';
                     row.querySelector('[name=scraperArgs]').value = item.ScraperArgs || '';
@@ -677,6 +688,7 @@
             form.querySelector('fieldset[name=global] [name=initBlooms][value=false]').checked = !globalConfig.InitBlooms;
 
             form.querySelector('fieldset[name=global] [name=etherscanKey]').value = globalConfig.EtherscanKey || '';
+            form.querySelector('fieldset[name=global] [name=defaultGateway]').value = globalConfig.DefaultGateway || 'https://ipfs.unchainedindex.io/ipfs/';
 
             form.querySelector('fieldset[name=global] [name=initIndex][value=true]').checked = globalConfig.InitIndex;
             form.querySelector('fieldset[name=global] [name=initIndex][value=false]').checked = !globalConfig.InitIndex;

--- a/configuration/static/index.html
+++ b/configuration/static/index.html
@@ -378,14 +378,14 @@
                         </span>
                     </div>
                 </label>
-                <!-- <label>
+                <label>
                     <span>
                         IPFS Gateway:
                     </span>
                     <div class="field">
                         <input type="url" name="ipfsGateway" placeholder="https://ipfs.unchainedindex.io/ipfs/">
                     </div>
-                </label> -->
+                </label>
                 <label>
                     <span>
                         Local Explorer:
@@ -671,7 +671,7 @@
                     row.querySelector('[name=rpc]').value = item.Rpc || '';
                     row.querySelector('[name=chainId]').value = item.ChainId || '';
                     row.querySelector('[name=symbol]').value = item.Symbol || '';
-                    // row.querySelector('[name=ipfsGateway]').value = item.IpfsGateway || '';
+                    row.querySelector('[name=ipfsGateway]').value = item.IpfsGateway || '';
                     row.querySelector('[name=localExplorer]').value = item.LocalExplorer || '';
                     row.querySelector('[name=remoteExplorer]').value = item.RemoteExplorer || '';
                     row.querySelector('[name=scraperArgs]').value = item.ScraperArgs || '';

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -10,7 +10,13 @@
   "contributors": [],
   "categories": ["Developer tools", "Blockchain", "Communications"],
   "keywords": ["trueblocks", "index", "indexing", "ipfs", "data"],
-  "backup": [],
+  "backup": [
+    {
+      "name": "trueblocks_data",
+      "path": "/root/.local/share/trueblocks",
+      "service": "core"
+    }
+  ],
   "exposable": [],
   "repository": {
     "type": "git",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,6 @@
   "shortDescription": "Lightweight indexing for any EVM-based blockchain",
   "description": "TrueBlocks is a collection of libraries, tools, and applications that improve access to the Ethereum data while remaining fully local. To configure, go to configure.trueblocks.public.dappnode",
   "type": "service",
-  "chain": "ethereum",
   "mainService": "core",
   "author": "TrueBlocks, LLC. (https://trueblocks.io)",
   "contributors": [],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,29 @@
-version: "3.4"
+version: "3.5"
 services:
   core:
     image: "trueblocks/core:v0.50.0-beta"
     entrypoint: |
       bash -c "\
-      while [ ! -f /configuration/configuration.sh ] \
+      while [ ! -f /configuration/entrypoint.sh ] \
       do \
           echo No configuration found. Please use TrueBlocks Configuration Tool first. \
           echo If you are using DAppNode, click Info tab above, then Settings link. \
           echo Will try to re-read the configuration in a few seconds \
           sleep 5 \
       done \
-      . /configuration/configuration.sh \
-      chifra daemon --api on --scrape blooms --monitor"
+      . /configuration/configuration.sh && \
+      sh /configuration/entrypoint.sh"
+    ports:
+      - "8080:8080/tcp"
     restart: unless-stopped
     volumes:
-      - "unchained:/index"
-      - "cache:/cache"
       - "configuration:/configuration"
+      - "trueblocks:/root/.local/share/trueblocks"
   configure:
     image: "trueblocks/config:v0.44.0-beta"
     restart: unless-stopped
     volumes:
       - "configuration:/output"
 volumes:
-  unchained: {}
-  cache: {}
   configuration: {}
+  trueblocks: {}


### PR DESCRIPTION
This PR includes the following changes to make the package (still in alpha) to work smoothly on a DappNode:

- Configuration service:
  - Add global `settings.defaultGateway` as a configurable parameter
  - Fix env variable for Etherscan API Key to point to `TB_KEYS_ETHERSCAN_APIKEY`
  - Fix env variable for chain IPFS Gateway
  - Add `SaveEntrypointScript` function to update the `entrypoint.sh` script that the package will use during deployment. This includes updating `chifra` opts based on what the user chooses on the configuration dashboard

- docker-compose.yaml:
  - Update startup script to `entrypoint.sh`
  - Add port mapping for chifra API
  - Update volume configuration for the core service in favour of using a single volume for the whole unchained index data. This allows persisting already scraped data between package updates and backups

- dappnone_package.json:
  - Enable `dnp` backup feature so Trueblocks data, cache, configuration, etc can be exported to other computers and/or be restored
  - Remove `chain` config property as this is only for tracking blockchain nodes' status